### PR TITLE
[2106] Adding Heroku setup for rendertron

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node bin/rendertron

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 > Rendertron is a headless Chrome rendering solution designed to render & serialise web pages on the fly.
 
 #### :hammer: Built with [Puppeteer](https://github.com/GoogleChrome/puppeteer)
+
 #### :cloud: Easy deployment to Google Cloud
+
 #### :mag: Improves SEO
 
 Rendertron is designed to enable your Progressive Web App (PWA) to serve the correct
@@ -14,12 +16,16 @@ and serializes the response back to the original request. To use Rendertron, you
 configures [middleware](#middleware) to determine whether to proxy a request to Rendertron.
 Rendertron is compatible with all client side technologies, including [web components](#web-components).
 
-**Demo endpoint**
+## Juked
 
-A demo Rendertron service is available at https://render-tron.appspot.com/. It is not designed
-to be used as a production endpoint. You can use it, but there are no uptime guarantees.
+### Deploying to Heroku
+
+Rendertron is deployed to the heroku `juked-rendertron` app whenever a commit is merged to production. The `app.yaml` file is no longer necessary.
+
+NOTE: The default Google App Engine configuration was causing cold start delays for standard env auto-scaling instances. This is a problem for googlebot, because we already have a slow page load time with firebase streaming. Switching to flex environment also had some setup issues, so opted to host in heroku which should be cheaper for the 100% availability (no warm up delay) use case.
 
 ## Contents
+
 - [Middleware](#middleware)
 - [API](#api)
   - [Render](#render)
@@ -39,14 +45,16 @@ to be used as a production endpoint. You can use it, but there are no uptime gua
   - [Troubleshooting](#troubleshooting)
 
 ## Middleware
+
 Once you have the service up and running, you'll need to implement the differential serving
 layer. This checks the user agent to determine whether prerendering is required.
 
 This is a list of middleware available to use with the Rendertron service:
- * [Express.js middleware](/middleware)
- * [Firebase functions](https://github.com/justinribeiro/pwa-firebase-functions-botrender) (Community maintained)
- * [ASP.net core middleware](https://github.com/galamai/AspNetCore.Rendertron) (Community maintained)
- * [Python (Django) middleware and decorator](https://github.com/frontendr/python-rendertron) (Community maintained)
+
+- [Express.js middleware](/middleware)
+- [Firebase functions](https://github.com/justinribeiro/pwa-firebase-functions-botrender) (Community maintained)
+- [ASP.net core middleware](https://github.com/galamai/AspNetCore.Rendertron) (Community maintained)
+- [Python (Django) middleware and decorator](https://github.com/frontendr/python-rendertron) (Community maintained)
 
 Rendertron is also compatible with [prerender.io middleware](https://prerender.io/documentation/install-middleware).
 Note: the user agent lists differ there.
@@ -54,19 +62,22 @@ Note: the user agent lists differ there.
 ## API
 
 ### Render
+
 ```
 GET /render/<url>
 ```
 
 The `render` endpoint will render your page and serialize your page. Options are
 specified as query parameters:
- * `mobile` defaults to `false`. Enable by passing `?mobile` to request the
+
+- `mobile` defaults to `false`. Enable by passing `?mobile` to request the
   mobile version of your site.
- * `refreshCache`: Pass `refreshCache=true` to ignore potentially cached render results 
- and treat the request as if it is not cached yet. 
- The new render result is used to replace the previous result.  
+- `refreshCache`: Pass `refreshCache=true` to ignore potentially cached render results
+  and treat the request as if it is not cached yet.
+  The new render result is used to replace the previous result.
 
 ### Screenshot
+
 ```
 GET /screenshot/<url>
 POST /screenshot/<url>
@@ -76,9 +87,10 @@ The `screenshot` endpoint can be used to verify that your page is rendering
 correctly.
 
 Both endpoints support the following query parameters:
- * `width` defaults to `1000` - specifies viewport width.
- * `height` defaults to `1000` - specifies viewport height.
- * `mobile` defaults to `false`. Enable by passing `?mobile` to request the
+
+- `width` defaults to `1000` - specifies viewport width.
+- `height` defaults to `1000` - specifies viewport height.
+- `mobile` defaults to `false`. Enable by passing `?mobile` to request the
   mobile version of your site.
 
 Additional options are available as a JSON string in the `POST` body. See
@@ -87,6 +99,7 @@ for available options. You cannot specify the `type` (defaults to `jpeg`) and
 `encoding` (defaults to `binary`) parameters.
 
 ### Invalidate Cache
+
 ```
 GET /invalidate/<url>
 ```
@@ -96,21 +109,26 @@ The `invalidate` endpoint will remove cache entried for `<url>` from the configu
 ## FAQ
 
 ### Query parameters
+
 When setting query parameters as part of your URL, ensure they are encoded correctly. In JS,
 this would be `encodeURIComponent(myURLWithParams)`. For example to specify `page=home`:
+
 ```
 https://render-tron.appspot.com/render/http://my.domain/%3Fpage%3Dhome
 ```
 
 ### Auto detecting loading function
+
 The service detects when a page has loaded by looking at the page load event, ensuring there
 are no outstanding network requests and that the page has had ample time to render.
 
 ### Rendering budget timeout
+
 There is a hard limit of 10 seconds for rendering. Ensure you don't hit this budget by ensuring
 your application is rendered well before the budget expires.
 
 ### Web components
+
 Headless Chrome supports web components but shadow DOM is difficult to serialize effectively.
 As such, [shady DOM](https://github.com/webcomponents/shadydom) (a lightweight shim for Shadow DOM)
 is required for web components.
@@ -125,19 +143,24 @@ set the query parameter `wc-inject-shadydom=true` when directing requests to the
 service. This renderer service will force the necessary polyfills to be loaded and enabled.
 
 ### Status codes
+
 Status codes from the initial requested URL are preserved. If this is a 200, or 304, you can
 set the HTTP status returned by the rendering service by adding a meta tag.
+
 ```html
 <meta name="render:status_code" content="404" />
 ```
 
 ## Running locally
+
 To install Rendertron and run it locally, first install Rendertron:
+
 ```bash
 npm install -g rendertron
 ```
 
 With Chrome installed on your machine run the Rendertron CLI:
+
 ```bash
 rendertron
 ```
@@ -145,7 +168,9 @@ rendertron
 ## Installing & deploying
 
 ### Building
+
 Clone and install dependencies:
+
 ```bash
 git clone https://github.com/GoogleChrome/rendertron.git
 cd rendertron
@@ -154,39 +179,42 @@ npm run build
 ```
 
 ### Running locally
+
 With a local instance of Chrome installed, you can start the server locally:
+
 ```bash
 npm run start
 ```
 
-### Deploying to Google Cloud Platform
-```
-gcloud app deploy app.yaml --project <your-project-id>
-```
-
 ### Deploying using Docker
+
 Rendertron no longer includes a Docker file. Instead, refer to
 [Puppeteer documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker)
 on how to deploy run headless Chrome in Docker.
 
 ### Config
+
 When deploying the service, set configuration variables by including a `config.json` in the
 root. Available configuration options:
- * `timeout` _default `10000`_ - set the timeout used to render the target page. 
- * `port` _default `3000`_ - set the port to use for running and listening the rendertron service. Note if process.env.PORT is set, it will be used instead.
- * `host` _default `0.0.0.0`_ - set the hostname to use for running and listening the rendertron service. Note if process.env.HOST is set, it will be used instead.
- * `width` _default `1000`_ - set the width (resolution) to be used for rendering the page.
- * `height` _default `1000`_ - set the height (resolution) to be used for rendering the page.
- * `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
- * `cacheConfig` - an object array to specify caching options
+
+- `timeout` _default `10000`_ - set the timeout used to render the target page.
+- `port` _default `3000`_ - set the port to use for running and listening the rendertron service. Note if process.env.PORT is set, it will be used instead.
+- `host` _default `0.0.0.0`_ - set the hostname to use for running and listening the rendertron service. Note if process.env.HOST is set, it will be used instead.
+- `width` _default `1000`_ - set the width (resolution) to be used for rendering the page.
+- `height` _default `1000`_ - set the height (resolution) to be used for rendering the page.
+- `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
+- `cacheConfig` - an object array to specify caching options
 
 #### cacheConfig
-* `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration
-* `cacheMaxEntries` _default `100`_ - set the maximum number of entries stored in the selected cache method. Set to `-1` to allow unlimited caching. If using the datastore caching method, setting this value over `1000` may lead to degraded performance as the query to determine the size of the cache may be too slow. If you want to allow a larger cache in `datastore` consider setting this to `-1` and managing the the size of your datastore using a method like this [Deleting Entries in Bulk](https://cloud.google.com/datastore/docs/bulk-delete)
-* `snapshotDir` _default `<your os's default tmp dir>/renderton`_ - **filesystem only** the directory the rendertron cache files will be stored in
+
+- `cacheDurationMinutes` _default `1440`_ - set an expiry time in minues, defaults to 24 hours. Set to -1 to disable cache Expiration
+- `cacheMaxEntries` _default `100`_ - set the maximum number of entries stored in the selected cache method. Set to `-1` to allow unlimited caching. If using the datastore caching method, setting this value over `1000` may lead to degraded performance as the query to determine the size of the cache may be too slow. If you want to allow a larger cache in `datastore` consider setting this to `-1` and managing the the size of your datastore using a method like this [Deleting Entries in Bulk](https://cloud.google.com/datastore/docs/bulk-delete)
+- `snapshotDir` _default `<your os's default tmp dir>/renderton`_ - **filesystem only** the directory the rendertron cache files will be stored in
 
 ##### Example
+
 An example config file specifying a memory cache, with a 2 hour expiration, and a maximum of 50 entries
+
 ```javascript
 {
     "cache": "memory",
@@ -198,6 +226,7 @@ An example config file specifying a memory cache, with a 2 hour expiration, and 
 ```
 
 ### Troubleshooting
+
 If you're having troubles with getting Headless Chrome to run in your
 environment, refer to the
 [troubleshooting guide](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5671,11 +5671,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "progress-bar-element": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress-bar-element/-/progress-bar-element-2.0.1.tgz",
-      "integrity": "sha1-6EkVNPGfyUlxBvMgxY7e0vCzI2c="
-    },
     "prop-assign": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prop-assign/-/prop-assign-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/GoogleChrome/rendertron",
   "engines": {
-    "node": ">=10"
+    "node": ">=12",
+    "npm": "6.14.5"
   },
   "main": "build/rendertron.js",
   "types": "build/rendertron.d.ts",
@@ -20,7 +21,8 @@
     "monitor-inspect": "nodemon --inspect src/main.js",
     "test": "(cd test-resources && npm install) && npm run build && ava build/test/app-test.js --timeout 5s",
     "start-emulator": "(gcloud beta emulators datastore start --no-store-on-disk --project emulator-project --host-port localhost:8380 &) 2>&1 | grep -m1 'now running'",
-    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT=emulator-project && ava build/test/*-cache-test.js"
+    "test-cache": "npm run start-emulator && $(gcloud beta emulators datastore env-init) && export GCLOUD_PROJECT=emulator-project && ava build/test/*-cache-test.js",
+    "heroku-postbuild": "npm run build"
   },
   "dependencies": {
     "@google-cloud/datastore": "^2.0.0",


### PR DESCRIPTION
Adds a Juked Heroku setup for Rendertron.  Full setup testing outlined here:

https://github.com/buffd-inc/juked/pull/2177

## Heroku
Rendertron seems to require quite a bit of memory for each request, so I'm using a 2x Professional Dyno.  When testing with a hobby dyno, it returned a black screen in the Google Search Console results.

![image](https://user-images.githubusercontent.com/8430216/84553145-142ab000-acc8-11ea-987f-6a378e8092f9.png)

## Next Steps
One thing to note is that currently Rendertron requests will run until the 10s hard limit and return whatever has been rendered by that point.  This is because I believe our firestore streaming connections keep the rendertron request open, so will need to do some research into how the browser request can detect the end of initial load, and if we can supply an initial render state within that window.

![image](https://user-images.githubusercontent.com/8430216/84553355-e5610980-acc8-11ea-871d-5417ca7b71ad.png)
